### PR TITLE
Defined GiskardControllerNode. Depends on giskard_msgs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_geometry_msgs
   interactive_markers 
   geometry_msgs
+  giskard_msgs
   kdl_conversions)
 
 ## Finding system dependencies which come without cmake
@@ -19,7 +20,8 @@ find_path(YAML_CPP_INCLUDE_DIRS yaml-cpp/yaml.h PATH_SUFFIXES include)
 find_library(YAML_CPP_LIBRARIES NAMES yaml-cpp)
 
 catkin_package(
-  CATKIN_DEPENDS roscpp roslib giskard tf2_ros tf2_geometry_msgs interactive_markers geometry_msgs kdl_conversions
+  INCLUDE_DIRS include
+  CATKIN_DEPENDS roscpp roslib giskard tf2_ros tf2_geometry_msgs interactive_markers geometry_msgs giskard_msgs kdl_conversions
   DEPENDS yaml_cpp
 )
 

--- a/controller_specs/pr2_left_arm_position_control.yaml
+++ b/controller_specs/pr2_left_arm_position_control.yaml
@@ -23,6 +23,8 @@ scope:
   - unit_x: {vector3: [1, 0, 0]}
   - unit_y: {vector3: [0, 1, 0]}
   - unit_z: {vector3: [0, 0, 1]}
+  - identity_rotation: {axis-angle: [unit-x, 0]} 
+  - zero_vec: {vector3: [0, 0, 0]}
 
 
   # definition of joint input variables

--- a/include/giskard_examples/GiskardControllerNode.hpp
+++ b/include/giskard_examples/GiskardControllerNode.hpp
@@ -55,11 +55,13 @@ public:
         active_ = false;
         moving_ = false;
         controller_started_ = false;
-        isInitialized_ = InitializeController();
+        isInitialized_ = false;
     }
 
     bool isInitialized()
     {
+        if(!isInitialized_)
+            isInitialized_ = InitializeController();
         return isInitialized_;
     }
 
@@ -67,17 +69,7 @@ private:
     bool InitializeController(void)
     {
         std::string controller_description;
-        std::string goal_topic, finished_topic;
-        if (!nh_.getParam("goal_topic", goal_topic))
-        {
-            ROS_ERROR("No goal topic defined.");
-            return false;
-        }
-        if (!nh_.getParam("finished_topic", finished_topic))
-        {
-            ROS_ERROR("No finished topic defined.");
-            return false;
-        }
+
         if (nh_.getParam("controller_description", controller_description))
         {
             if (nh_.getParam("joint_names", joint_names_))
@@ -97,9 +89,9 @@ private:
     
                 enable_service_ = nh_.advertiseService("SetEnable", &ControllerType::doSetEnable, this);
                 ROS_INFO("Waiting for seggoal.");
-                goal_sub_ = nh_.subscribe(goal_topic, 0, &ControllerType::goalCallback, this);
+                goal_sub_ = nh_.subscribe("goal", 0, &ControllerType::goalCallback, this);
                 js_sub_ = nh_.subscribe("joint_states", 0, &ControllerType::jointCallback, this);
-                done_adv_ = nh_.advertise<giskard_msgs::Finished>(finished_topic, 0);
+                done_adv_ = nh_.advertise<giskard_msgs::Finished>("finished", 0);
             }
             else
             {
@@ -217,4 +209,4 @@ private:
 
 }
 
-#endif
+#endiff

--- a/include/giskard_examples/GiskardControllerNode.hpp
+++ b/include/giskard_examples/GiskardControllerNode.hpp
@@ -1,0 +1,220 @@
+/*
+* Copyright (C) 2015, 2016 Mihai Pomarlan <blandc@cs.uni-bremen.de>
+* Jannik Buckelo <jannikbu@cs.uni-bremen.de>,
+* Georg Bartels <georg.bartels@cs.uni-bremen.de>,*
+*
+* This file is part of giskard_examples.
+*
+* giskard_examples is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public License
+* as published by the Free Software Foundation; either version 2
+* of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+*/
+
+
+#ifndef __GISKARD_CONTROLLER_NODE_HPP__
+#define __GISKARD_CONTROLLER_NODE_HPP__
+
+#include <ros/ros.h>
+#include <ros/package.h>
+
+#include <sensor_msgs/JointState.h>
+#include <std_msgs/Float64.h>
+#include <geometry_msgs/Point.h>
+#include <yaml-cpp/yaml.h>
+#include <giskard/giskard.hpp>
+
+#include <giskard_msgs/SetEnable.h>
+#include <giskard_msgs/Finished.h>
+#include <boost/bind.hpp>
+
+namespace gcn{
+
+template<int goalSize, typename GoalMsgType> class GiskardControllerNode
+{
+public:
+    typedef GiskardControllerNode<goalSize, GoalMsgType> ControllerType;
+    typedef boost::shared_ptr<GoalMsgType> GoalMsgPtr;
+    typedef boost::shared_ptr<GoalMsgType const> GoalMsgConstPtr;
+    typedef void(*GoalParserFnPtr)(GoalMsgConstPtr const& goalMsg, std::vector<double> &goalValues);
+
+    GiskardControllerNode(GoalParserFnPtr goalParser, std::string const& initString=std::string("~")):
+        goalSize_(goalSize), nh_(initString), goalParser_(goalParser)
+    {
+        nh_.param("nWSR", nWSR_, 10);
+        nh_.param("is_done_topic", doneTopic_, std::string("doneMovement"));
+        active_ = false;
+        moving_ = false;
+        controller_started_ = false;
+        isInitialized_ = InitializeController();
+    }
+
+    bool isInitialized()
+    {
+        return isInitialized_;
+    }
+
+private:
+    bool InitializeController(void)
+    {
+        std::string controller_description;
+        std::string goal_topic, finished_topic;
+        if (!nh_.getParam("goal_topic", goal_topic))
+        {
+            ROS_ERROR("No goal topic defined.");
+            return false;
+        }
+        if (!nh_.getParam("finished_topic", finished_topic))
+        {
+            ROS_ERROR("No finished topic defined.");
+            return false;
+        }
+        if (nh_.getParam("controller_description", controller_description))
+        {
+            if (nh_.getParam("joint_names", joint_names_))
+            {
+                YAML::Node node = YAML::Load(controller_description);
+                ROS_INFO("Loaded controller description.");
+                giskard::QPControllerSpec spec = node.as< giskard::QPControllerSpec >();
+                ROS_INFO("Parsed controller description.");
+                controller_ = giskard::generate(spec);
+                ROS_INFO("Generated controller description.");
+                state_ = Eigen::VectorXd::Zero(joint_names_.size() + goalSize_);
+                ROS_INFO("Created a state.");
+                controller_started_ = false;
+    
+                for (std::vector<std::string>::iterator it = joint_names_.begin(); it != joint_names_.end(); ++it)
+                    vel_controllers_.push_back(nh_.advertise<std_msgs::Float64>("/" + *it + "/vel_cmd", 1));
+    
+                enable_service_ = nh_.advertiseService("SetEnable", &ControllerType::doSetEnable, this);
+                ROS_INFO("Waiting for seggoal.");
+                goal_sub_ = nh_.subscribe(goal_topic, 0, &ControllerType::goalCallback, this);
+                js_sub_ = nh_.subscribe("joint_states", 0, &ControllerType::jointCallback, this);
+                done_adv_ = nh_.advertise<giskard_msgs::Finished>(finished_topic, 0);
+            }
+            else
+            {
+                ROS_ERROR("Parameter 'joint_names' not found in namespace '%s'.", nh_.getNamespace().c_str());
+                return false;
+            }
+        }
+        else
+        {
+            ROS_ERROR("Parameter 'controller_description' not found in namespace '%s'.", nh_.getNamespace().c_str());
+            return false;
+        }
+        return true;
+    }
+
+    void jointCallback(const sensor_msgs::JointState::ConstPtr& msg)
+    {
+        if ((!controller_started_) || (!active_))
+          return;
+
+      // TODO: turn this into a map!
+      // is there a more efficient way?
+        for (unsigned int i=0; i < joint_names_.size(); i++)
+        {
+            for (unsigned int j=0; j < msg->name.size(); j++)
+            {
+                if (msg->name[j].compare(joint_names_[i]) == 0)
+                {
+                    state_[i] = msg->position[j];
+                }
+            }
+        }
+
+        if (controller_.update(state_, nWSR_))
+        {
+            Eigen::VectorXd commands = controller_.get_command();
+            double commPower = 0;
+            for (unsigned int i=0; i < vel_controllers_.size(); i++)
+            {
+                std_msgs::Float64 command;
+                command.data = commands[i];
+                commPower += (commands[i]*commands[i]);
+                vel_controllers_[i].publish(command);
+            }
+            if(moving_ && (commPower < 0.001))
+            {
+                done_adv_.publish(giskard_msgs::Finished());
+                moving_ = false;
+            }
+            else
+                moving_ = true;
+        }
+        else
+        {
+            ROS_WARN("Update failed.");
+            // TODO: remove or change to ros_debug
+            std::cout << "State " << state_ << std::endl;
+        }
+    }
+    void goalCallback(const GiskardControllerNode<goalSize, GoalMsgType>::GoalMsgConstPtr& msg)
+    {
+        std::vector<double> aux; aux.clear();
+        goalParser_(msg, aux);
+    
+        int maxK = aux.size();
+    
+        for(int k = 0; k < maxK; k++)
+            state_[joint_names_.size() + k] = aux[k];
+    
+        if(!active_)
+            return;
+    
+        if (!controller_started_)
+        {
+            if (controller_.start(state_, nWSR_))
+            {
+                ROS_INFO("Controller started.");
+                controller_started_ = true;
+            }
+            else
+            {
+                ROS_ERROR("Couldn't start controller.");
+            }
+        }
+    }
+
+    bool doSetEnable(giskard_msgs::SetEnable::Request &req, giskard_msgs::SetEnable::Response &res)
+    {
+        active_ = req.enable;
+        return true;
+    }
+
+    int goalSize_;
+    ros::NodeHandle nh_;
+    GoalParserFnPtr goalParser_;
+    int nWSR_;
+    bool active_;
+    bool moving_;
+    std::string doneTopic_;
+    bool isInitialized_;
+
+    giskard::QPController controller_;
+    std::vector<std::string> joint_names_;
+    std::vector<ros::Publisher> vel_controllers_;
+    ros::Subscriber js_sub_;
+    Eigen::VectorXd state_;
+    bool controller_started_;
+
+    ros::ServiceServer enable_service_;
+    ros::Subscriber goal_sub_;
+
+    ros::Publisher done_adv_;
+
+};
+
+}
+
+#endif

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>roslib</depend>
   <depend>interactive_markers</depend>
   <depend>geometry_msgs</depend>
+  <depend>giskard_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>kdl_conversions</depend>


### PR DESCRIPTION
Added a GiskardControllerNode template class. Encapsulates the ROS node setup to initialize and run a controller, including setup of enable service, finished and goal topics. Depends on a new package giskard_msgs which is available in my repositories. Example use is in pizzaninja-controllers from pizzaninja-aux.
