### PR TITLE
Added an option to publish Twist messages.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   std_srvs
   giskard_msgs
-  kdl_conversions)
+  kdl_conversions kdl_parser)
 
 ## Finding system dependencies which come without cmake
 find_package(PkgConfig)
@@ -24,7 +24,7 @@ find_library(YAML_CPP_LIBRARIES NAMES yaml-cpp)
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp roslib giskard_core tf2_ros tf2_geometry_msgs interactive_markers geometry_msgs giskard_msgs kdl_conversions
+  CATKIN_DEPENDS roscpp roslib giskard_core tf2_ros tf2_geometry_msgs interactive_markers geometry_msgs giskard_msgs kdl_conversions kdl_parser
   DEPENDS yaml_cpp
 )
 

--- a/launch/joint_sep.launch
+++ b/launch/joint_sep.launch
@@ -1,10 +1,13 @@
 <launch>
 
+  <arg name="output_twist" default="true" />
+  <arg name="robot_description_parameter_name" default="/robot_description" />
+
       <node pkg="giskard_ros"
             type="joint_state_separator" name="pr2_cmd_separator" output="screen" >
         <rosparam param="joint_names" file="$(find giskard_pr2)/config/pr2_upper_body.yaml" />
-        <param name="robot_description_parameter_name" value="/robot_description" type="str" />
-        <param name="output_twist" value="true" type="bool" />
+        <param name="robot_description_parameter_name" value="$(arg robot_description_parameter_name)" type="str" />
+        <param name="output_twist" value="$(arg output_twist)" type="bool" />
         <remap from="~joint_states" to="/whole_body_controller/velocity_controller/command" />
       </node>
 

--- a/launch/joint_sep.launch
+++ b/launch/joint_sep.launch
@@ -6,6 +6,11 @@
       <node pkg="giskard_ros"
             type="joint_state_separator" name="pr2_cmd_separator" output="screen" >
         <rosparam param="joint_names" file="$(find giskard_pr2)/config/pr2_upper_body.yaml" />
+        <rosparam param="x_axis">[0.0, -1.0, 0.0]</rosparam>
+        <rosparam param="y_axis">[1.0, 0.0, 0.0]</rosparam>
+        <rosparam param="z_axis">[0.0, 0.0, 1.0]</rosparam>
+        <param name="linear_scale" value="1.0" type="double" />
+        <param name="angular_scale" value="57.0" type="double" />
         <param name="robot_description_parameter_name" value="$(arg robot_description_parameter_name)" type="str" />
         <param name="output_twist" value="$(arg output_twist)" type="bool" />
         <remap from="~joint_states" to="/whole_body_controller/velocity_controller/command" />

--- a/launch/joint_sep.launch
+++ b/launch/joint_sep.launch
@@ -1,0 +1,11 @@
+<launch>
+
+      <node pkg="giskard_ros"
+            type="joint_state_separator" name="pr2_cmd_separator" output="screen" >
+        <rosparam param="joint_names" file="$(find giskard_pr2)/config/pr2_upper_body.yaml" />
+        <param name="robot_description_parameter_name" value="/robot_description" type="str" />
+        <param name="output_twist" value="true" type="bool" />
+        <remap from="~joint_states" to="/whole_body_controller/velocity_controller/command" />
+      </node>
+
+</launch>

--- a/package.xml
+++ b/package.xml
@@ -28,4 +28,5 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>kdl_conversions</depend>
+  <depend>kdl_parser</depend>
 </package>

--- a/src/giskard_ros/joint_state_separator.cpp
+++ b/src/giskard_ros/joint_state_separator.cpp
@@ -26,20 +26,39 @@
 #include <std_msgs/Float64.h>
 #include <giskard_ros/ros_utils.hpp>
 
+#include <urdf/model.h>
+#include <geometry_msgs/Twist.h>
+
 namespace giskard_ros
 {
   class JointStateSeparator
   {
     public:
-      JointStateSeparator(const ros::NodeHandle& nh) : nh_(nh) {}
+      JointStateSeparator(const ros::NodeHandle& nh) : nh_(nh), robot_model_loaded_(false), output_twist_(false) {}
       ~JointStateSeparator() {}
 
       void start() 
       {
+        std::string robot_description_parameter = readParam<std::string>(nh_, "robot_description_parameter_name");
+        output_twist_ = readParam<bool>(nh_, "output_twist");
+        if (output_twist_ && !robot_model_.initParam(robot_description_parameter))
+        {
+            throw std::runtime_error("Could not read urdf from parameter server at '" + robot_description_parameter + "'.");
+        }
+
         joint_names_ = readParam< std::vector<std::string> >(nh_, "joint_names");
 
         for (size_t i=0; i<joint_names_.size(); ++i)
-          pubs_.push_back(nh_.advertise<std_msgs::Float64>("/" + joint_names_[i].substr(0, joint_names_[i].size() - 6) + "_velocity_controller/command", 1));
+        {
+            if(output_twist_)
+            {
+                pubs_.push_back(nh_.advertise<geometry_msgs::Twist>("/" + joint_names_[i].substr(0, joint_names_[i].size() - 6) + "_velocity_controller/command", 1));
+            }
+            else
+            {
+                pubs_.push_back(nh_.advertise<std_msgs::Float64>("/" + joint_names_[i].substr(0, joint_names_[i].size() - 6) + "_velocity_controller/command", 1));
+            }
+        }
 
         sub_ = nh_.subscribe("joint_states", 1, &JointStateSeparator::callback, this);
       }
@@ -49,6 +68,10 @@ namespace giskard_ros
       ros::Subscriber sub_;
       std::vector<ros::Publisher> pubs_;
       std::vector<std::string> joint_names_;
+
+      urdf::Model robot_model_;
+      bool robot_model_loaded_;
+      bool output_twist_;
 
       void callback(const sensor_msgs::JointState::ConstPtr& msg)
       {
@@ -67,9 +90,39 @@ namespace giskard_ros
           if (name_cmd_map.find(joint_names_[i]) == name_cmd_map.end())
             throw std::runtime_error("Could not find velocity command for joint '" + joint_names_[i] + "'.");
 
-          std_msgs::Float64 out_msg;
-          out_msg.data = name_cmd_map.find(joint_names_[i])->second;
-          pubs_[i].publish(out_msg);
+          if(output_twist_)
+          {
+            double vel = name_cmd_map.find(joint_names_[i])->second;
+            if (robot_model_.joints_.find(joint_names_[i]) == robot_model_.joints_.end() )
+                throw std::runtime_error("Could not find link with name '" + joint_names_[i] + "'.");
+            urdf::JointConstSharedPtr joint = robot_model_.joints_.find(joint_names_[i])->second;
+            bool prismatic = (joint->type == urdf::Joint::PRISMATIC);
+            bool revolute = ((joint->type == urdf::Joint::REVOLUTE) || (joint->type == urdf::Joint::CONTINUOUS));
+
+            geometry_msgs::Twist out_msg;
+            out_msg.linear.x = out_msg.linear.y = out_msg.linear.z = 0.0;
+            out_msg.angular.x = out_msg.angular.y = out_msg.angular.z = 0.0;
+            if(prismatic)
+            {
+                out_msg.linear.x = joint->axis.x*vel;
+                out_msg.linear.y = joint->axis.y*vel;
+                out_msg.linear.z = joint->axis.z*vel;
+            }
+            if(revolute)
+            {
+                out_msg.angular.x = joint->axis.x*vel;
+                out_msg.angular.y = joint->axis.y*vel;
+                out_msg.angular.z = joint->axis.z*vel;
+            }
+            pubs_[i].publish(out_msg);
+
+          }
+          else
+          {
+              std_msgs::Float64 out_msg;
+              out_msg.data = name_cmd_map.find(joint_names_[i])->second;
+              pubs_[i].publish(out_msg);
+          }
         }
       }
   };


### PR DESCRIPTION
Some simulated controllers I'm about to use expect Twist messages for the joints, so I've added some code for the joint_state_separator node to publish such messages. By default, the node will still publish Float64 messages as before, but with an optional parameter this can be switched to Twist.